### PR TITLE
Enable for HDF-3.3.X

### DIFF
--- a/dp-cluster-setup-utility.py
+++ b/dp-cluster-setup-utility.py
@@ -991,7 +991,7 @@ class AmbariPrerequisites:
 
   def satisfied(self):
     if not self.stack_supported():
-      print 'The stack version (%s) is not supported. Supported stacks are: HDP-3.1 or newer.' % self.ambari.installed_stack()
+      print 'The stack version (%s) is not supported. Supported stacks are: HDP-3.1/HDF-3.2 or newer.' % self.ambari.installed_stack()
       return False
     if not self.security_type_supported():
       print 'Your cluster is not kerberied. Please enable Kerberos using Ambari first.'
@@ -1005,8 +1005,15 @@ class AmbariPrerequisites:
     return True
 
   def stack_supported(self):
+    return self.hdp_supported_version or self.hdf_supported_version
+
+  def hdp_supported_version(self):
     stack = self.ambari.installed_stack()
     return stack.name == 'HDP' and stack.version.startswith('3.1')
+  
+  def hdf_supported_version(self):
+    stack = self.ambari.installed_stack()
+    return stack.name == 'HDF' and stack.version.startswith('3.2')
 
   def security_type_supported(self):
     return self.ambari.cluster.security_type == 'KERBEROS'

--- a/dp-cluster-setup-utility.py
+++ b/dp-cluster-setup-utility.py
@@ -991,7 +991,7 @@ class AmbariPrerequisites:
 
   def satisfied(self):
     if not self.stack_supported():
-      print 'The stack version (%s) is not supported. Supported stacks are: HDP-3.1/HDF-3.2 or newer.' % self.ambari.installed_stack()
+      print 'The stack version (%s) is not supported. Supported stacks are: HDP-3.1/HDF-3.3 or newer.' % self.ambari.installed_stack()
       return False
     if not self.security_type_supported():
       print 'Your cluster is not kerberied. Please enable Kerberos using Ambari first.'
@@ -1013,7 +1013,7 @@ class AmbariPrerequisites:
   
   def hdf_supported_version(self):
     stack = self.ambari.installed_stack()
-    return stack.name == 'HDF' and stack.version.startswith('3.2')
+    return stack.name == 'HDF' and stack.version.startswith('3.3')
 
   def security_type_supported(self):
     return self.ambari.cluster.security_type == 'KERBEROS'

--- a/dp-cluster-setup-utility.py
+++ b/dp-cluster-setup-utility.py
@@ -1005,7 +1005,7 @@ class AmbariPrerequisites:
     return True
 
   def stack_supported(self):
-    return self.hdp_supported_version or self.hdf_supported_version
+    return self.hdp_supported_version() or self.hdf_supported_version()
 
   def hdp_supported_version(self):
     stack = self.ambari.installed_stack()


### PR DESCRIPTION
Simple DP does not need specific inputs to identify HDP/HDF cluster other than ambari user. 
This change only enable HDF