### PR TITLE
BUG-118936:In knox services STREAMSMSGMGR service is known as SMM

### DIFF
--- a/dp-cluster-setup-utility.py
+++ b/dp-cluster-setup-utility.py
@@ -838,7 +838,7 @@ class DpProxyTopology:
     return self.role('BEACON', self.beacon_url()) if 'BEACON' in self.role_names else ''
 
   def streamsmsgmgr(self):
-    return self.role('STREAMSMSGMGR', self.streamsmsgmgr_url()) if 'STREAMSMSGMGR' in self.role_names else ''
+    return self.role('SMM', self.streamsmsgmgr_url()) if 'STREAMSMSGMGR' in self.role_names else ''
 
   def role(self, name, url, version=''):
     version_str = ''


### PR DESCRIPTION
In ambari the service the known as STREAMSMSGMGR but in knox its smm.
that requires the role name present in dp-proxy to be named as SMM .