### PR TITLE
BUG-119682:Handling registration of multiple Clusters

### DIFF
--- a/dp-cluster-setup-utility.py
+++ b/dp-cluster-setup-utility.py
@@ -1032,25 +1032,26 @@ class DataPlane:
     registration_request = []
     for cluster_name in cluster_names:
       cluster_obj = next(obj for obj in cm.clusters if obj.cluster_name == cluster_name)
-      print("Enter details for cluster : %s" % cluster_name)
-      registration_request.append({
-        'dcName': user.input('Data Center Name', 'reg.dc.name'),
-        'managerUri': str(cm.base_url),
-        'ambariUrl': '',
-        'ambariIpAddress': '',
-        'location': 6789,
-        'isDatalake': self.has_selected_app('Data Steward Studio (DSS)'),
-        'name': cluster_obj.cluster_name,
-        'description': user.input('Cluster Descriptions', 'reg.description'),
-        'state': 'TO_SYNC',
-        'managerAddress': cm.base_url.ip_address(),
-        'allowUntrusted': True,
-        'behindGateway': False,
-        'knoxEnabled': False,
-        'managerType': "cloudera-manager",
-        'clusterType': cluster_obj.type,
-        'properties': {'tags': []}
-      })
+      if cluster_obj:
+        print("Enter details for cluster : %s" % cluster_name)
+        registration_request.append({
+          'dcName': user.input('Data Center Name', 'reg.dc.name'),
+          'managerUri': str(cm.base_url),
+          'ambariUrl': '',
+          'ambariIpAddress': '',
+          'location': 6789,
+          'isDatalake': self.has_selected_app('Data Steward Studio (DSS)'),
+          'name': cluster_obj.cluster_name,
+          'description': user.input('Cluster Descriptions', 'reg.description'),
+          'state': 'TO_SYNC',
+          'managerAddress': cm.base_url.ip_address(),
+          'allowUntrusted': True,
+          'behindGateway': False,
+          'knoxEnabled': False,
+          'managerType': "cloudera-manager",
+          'clusterType': cluster_obj.type,
+          'properties': {'tags': []}
+        })
     return registration_request
 
   def tokens(self):
@@ -1822,8 +1823,8 @@ if __name__ == '__main__':
   print '\nIf you are Working with CDH clusters managed by Cloudera Manager :'
   print '\nPlease ensure you are running from one of the hosts of the cluster\n'
 
-  # if not ScriptPrerequisites().satisfied():
-  #   sys.exit(1)
+  if not ScriptPrerequisites().satisfied():
+    sys.exit(1)
   # Get the cluster type and execute the flow
   print('Tell me about your Cluster type')
   flow_manager = FlowManager(user.cluster_type_input('Cluster Type ','cluster.type'))

--- a/dp-cluster-setup-utility.py
+++ b/dp-cluster-setup-utility.py
@@ -614,33 +614,35 @@ class ClouderaManager(BaseClusterManager):
     self.base_url = base_url
     self.client = CMRestClient(base_url / 'api' / api_version, credentials)
     self.api_version = api_version
-    self.cluster = self._find_cluster_details()
+    self.clusters = self._find_clusters_detail()
+    self.total_clusters = self._total_clusters()
     self.internal_host = self._find_internal_host_name()
 
-  def _find_cluster_details(self):
-    cluster = self._find_cluster()
-    kerb = self.client.cluster_api_instance().get_kerberos_info(cluster.name)
-    cluster.security_type = ""
-    if kerb.kerberized :
-      cluster.security_type = "KERBEROS"
-    return CMCluster(cluster,self.client)
+  def _find_clusters_detail(self):
+    clusters = self._find_clusters()
+    return [CMCluster(cluster,self.client) for cluster in clusters]
   
   def _find_repository_version(self, cluster_name):
     pass
 
-  def _find_cluster(self):
+  def _total_clusters(self):
+    return len(self.clusters) if self.clusters else 0
+
+  def _find_clusters(self):
     try:
       response = self.client.cluster_api_instance().read_clusters(view='full')
-      return response.items[0]
+      return response.items
     except ApiException as e:
       raise NoClusterFound(e)
 
+  def get_cluster_instance(self, cluster_name):
+    for cluster in self.clusters:
+      if cluster.name == cluster_name:
+        return cluster
+    return None
+  
   def _find_internal_host_name(self):
     pass
-
-  def installed_stack(self):
-    stack_ver = self.cluster.version
-    return Stack('CDH', stack_ver, self.client)
 
   def current_stack_version(self):
     pass
@@ -736,12 +738,19 @@ class NoConfigFound(Exception): pass
 
 class CMCluster(BaseCluster):
   def __init__(self, cluster, client):
+    self.client = client
     self.cluster = cluster
     self.cluster_name = cluster.name
     self.version = cluster.full_version
     self.type = 'CDH'
-    self.security_type = cluster.security_type
-    self.client = client
+    self.security_type = self._get_cluster_security_type(cluster)
+
+  def _get_cluster_security_type(self,cluster):
+    kerb = self.client.cluster_api_instance().get_kerberos_info(self.cluster.name)
+    security_type = ""
+    if kerb.kerberized :
+      security_type = "KERBEROS"
+    return security_type
 
   def service(self, service_name):
     try:
@@ -757,6 +766,9 @@ class CMCluster(BaseCluster):
     except ApiException as e:
       raise e
 
+  def installed_stack(self):
+    stack_ver = self.version
+    return Stack('CDH', stack_ver, self.client)
   #
   # TODO: currently service name and service types in CM BAsed cluster differ.
   #
@@ -974,13 +986,13 @@ class DataPlane:
       return resp
     return [resp]
   
-  def register_cm(self, cm, user):
+  def register_cm(self, cm, user, clusters):
     if not self.version.startswith("1.3"):
       print("Registering CM Based cluster is not supported in DP %s" % self.version)
       return []
     _, resp = self.client.post(
       'api/lakes',
-      data=self.registration_request_cm(cm, user),
+      data=self.registration_request_cm(cm, user, clusters),
       headers=[Header.content_type('application/json'), self.token_cookies()]
     )
     return resp
@@ -1016,25 +1028,30 @@ class DataPlane:
       'managerType': "ambari",
     }
 
-  def registration_request_cm(self, cm, user):
-    return [{
-      'dcName': user.input('Data Center Name', 'reg.dc.name'),
-      'managerUri': str(cm.base_url),
-      'ambariUrl': '',
-      'ambariIpAddress': '',
-      'location': 6789,
-      'isDatalake': self.has_selected_app('Data Steward Studio (DSS)'),
-      'name': cm.cluster.cluster_name,
-      'description': user.input('Cluster Descriptions', 'reg.description'),
-      'state': 'TO_SYNC',
-      'managerAddress': cm.base_url.ip_address(),
-      'allowUntrusted': True,
-      'behindGateway': False,
-      'knoxEnabled': False,
-      'managerType': "cloudera-manager",
-      'clusterType': cm.cluster.type,
-      'properties': {'tags': []}
-    }]
+  def registration_request_cm(self, cm, user, cluster_names):
+    registration_request = []
+    for cluster_name in cluster_names:
+      cluster_obj = next(obj for obj in cm.clusters if obj.cluster_name == cluster_name)
+      print("Enter details for cluster : %s" % cluster_name)
+      registration_request.append({
+        'dcName': user.input('Data Center Name', 'reg.dc.name'),
+        'managerUri': str(cm.base_url),
+        'ambariUrl': '',
+        'ambariIpAddress': '',
+        'location': 6789,
+        'isDatalake': self.has_selected_app('Data Steward Studio (DSS)'),
+        'name': cluster_obj.cluster_name,
+        'description': user.input('Cluster Descriptions', 'reg.description'),
+        'state': 'TO_SYNC',
+        'managerAddress': cm.base_url.ip_address(),
+        'allowUntrusted': True,
+        'behindGateway': False,
+        'knoxEnabled': False,
+        'managerType': "cloudera-manager",
+        'clusterType': cluster_obj.type,
+        'properties': {'tags': []}
+      })
+    return registration_request
 
   def tokens(self):
     thief = CookieThief()
@@ -1100,9 +1117,8 @@ class DataPlane:
       },
       headers=[Header.content_type('application/json'), self.token_cookies()]
     )
-    if len(resp) > 0:
-      return True
-    return False
+    return resp
+
 
 class TokenTopology:
   TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
@@ -1568,24 +1584,24 @@ class AmbariPrerequisites(BasePrerequisites):
 class CMPrerequisites(BasePrerequisites):
   def __init__(self, cm):
     self.cm = cm
-    self.knox_host = cm.cluster.knox_host()
 
   def satisfied(self):
-    if not self.stack_supported():
-      print('The stack version (%s) is not supported. Supported stacks are: CDH-5.17/CDH-6.3 or newer.' % self.cm.installed_stack())
-      return False
+    for  cluster in self.cm.clusters:
+      if not self.stack_supported(cluster):
+        print('The stack version (%s) is not supported for %s. Supported stacks are: CDH-5.17/CDH-6.3 or newer.' % (cluster.installed_stack(), cluster.cluster_name))
+        return False
     return True
 
-  def stack_supported(self):
-    stack = self.cm.installed_stack()
+  def stack_supported(self, cluster):
+    stack = cluster.installed_stack()
     check_version = False
     (major,minor) = stack.version.split('.')[:2]
-    if (major == '5' and int(minor) >= 17) or (major == '6' and int(minor) >= 1):
+    if (major == '5' and int(minor) >= 17) or (major == '6' and int(minor) >= 3):
       check_version = True
     return stack.name == 'CDH' and check_version
 
   def security_type_supported(self):
-    return self.cm.cluster.security_type == 'KERBEROS'
+    pass
 
 
 class CookieThief:
@@ -1743,6 +1759,7 @@ class CMRegistrationFlow(BaseRegistrationFlow):
     self.dp_instance = None
 
   def execute(self):
+    
     self.dp_instance = self.get_dp_instance()
     dp = self.dp_instance
     if not dp.version.startswith("1.3"):
@@ -1750,17 +1767,47 @@ class CMRegistrationFlow(BaseRegistrationFlow):
       return 1
     print "\nTell me about Cloudera Manager Instance"
     cm = ClouderaManager(user.url_input('CM URL', 'cm.url'), user.credential_input('CM admin', 'cm.admin'))
+
     if not CMPrerequisites(cm).satisfied():
       return 1
     
-    if not dp.check_cm(cm):
-      return 1
+    clusters_resp_from_dp = dp.check_cm(cm)
 
-    print 'Registering cluster to DataPlane...'
-    response = dp.register_cm(cm, user)
-    if not response:
+    if not clusters_resp_from_dp:
       return 1
-    return self.handle_registration_response(response)
+    
+    clusters_registered = [cluster.get("name") for cluster in clusters_resp_from_dp if not cluster.get("isUnregistered")]
+    clusters_not_registered = [cluster.get("name") for cluster in clusters_resp_from_dp if cluster.get("isUnregistered")]
+    clusters_to_register = []
+
+    print "Total clusters managed by Cloudera Manager Instance : %s" % cm.total_clusters
+    if cm.total_clusters == 1:
+      clusters_to_register = clusters_not_registered
+    elif cm.total_clusters > 1:
+      print "Clusters already registered in DataPlane : %s" % ','.join([cluster for cluster in clusters_registered])
+      print "Clusters which can be registered in DataPlane : %s" % ','.join([cluster for cluster in clusters_not_registered])
+      if len(clusters_not_registered) > 0:
+        install_all = user.decision('%s y/n' % "Register all", "cm.register_all", default=False)
+        if install_all:
+          clusters_to_register = clusters_not_registered
+        else:
+          user_provided_clusters = []
+          cluster_input_file = user.input('Enter full path of file containing cluster names ', 'cm.cluster_file')
+          with open(cluster_input_file, 'r') as f:
+            for line in f:
+              user_provided_clusters.append(line.strip())
+          clusters_to_register = [ cluster for cluster in user_provided_clusters if cluster in clusters_not_registered]
+        print "\nClusters which will be registered in DataPlane : %s" % ','.join([cluster for cluster in clusters_to_register])
+    
+    if clusters_to_register:
+      print 'Registering cluster to DataPlane...'
+      response = dp.register_cm(cm, user, clusters_to_register)
+      if not response:
+        return 1
+      return self.handle_registration_response(response)
+    else:
+      print 'No valid cluster found to be registered to DataPlane...'
+      return 0
     
 
 """
@@ -1772,11 +1819,11 @@ if __name__ == '__main__':
   print '\nThis script works with Cluster manager - Ambari or Cloudera Manager.'
   print '\nIf you are Working with HDP/HDF Clusters managed by Ambari : '
   print '\nPlease ensure that your cluster has kerberos enabled, Ambari has been configured to use kerberos for authentication, and Knox is installed. Once those steps have been done, run this script from the Knox host and follow the steps and prompts to complete the cluster registration process.\n'
-  print '\nIf you are Working with CDH clusters managed by Cloudera Manahger :'
+  print '\nIf you are Working with CDH clusters managed by Cloudera Manager :'
   print '\nPlease ensure you are running from one of the hosts of the cluster\n'
 
-  if not ScriptPrerequisites().satisfied():
-    sys.exit(1)
+  # if not ScriptPrerequisites().satisfied():
+  #   sys.exit(1)
   # Get the cluster type and execute the flow
   print('Tell me about your Cluster type')
   flow_manager = FlowManager(user.cluster_type_input('Cluster Type ','cluster.type'))

--- a/dp-cluster-setup-utility.py
+++ b/dp-cluster-setup-utility.py
@@ -1031,8 +1031,9 @@ class DataPlane:
   def registration_request_cm(self, cm, user, cluster_names):
     registration_request = []
     for cluster_name in cluster_names:
-      cluster_obj = next(obj for obj in cm.clusters if obj.cluster_name == cluster_name)
-      if cluster_obj:
+      cluster_objects = filter(lambda c: c.cluster_name == cluster_name, cm.clusters)
+      if cluster_objects:
+        cluster_obj = cluster_objects[0]
         print("Enter details for cluster : %s" % cluster_name)
         registration_request.append({
           'dcName': user.input('Data Center Name', 'reg.dc.name'),
@@ -1589,7 +1590,7 @@ class CMPrerequisites(BasePrerequisites):
   def satisfied(self):
     for  cluster in self.cm.clusters:
       if not self.stack_supported(cluster):
-        print('The stack version (%s) is not supported for %s. Supported stacks are: CDH-5.17/CDH-6.3 or newer.' % (cluster.installed_stack(), cluster.cluster_name))
+        print('The stack version (%s) is not supported for %s. Supported stacks are: CDH-5.17  or newer.' % (cluster.installed_stack(), cluster.cluster_name))
         return False
     return True
 
@@ -1597,7 +1598,7 @@ class CMPrerequisites(BasePrerequisites):
     stack = cluster.installed_stack()
     check_version = False
     (major,minor) = stack.version.split('.')[:2]
-    if (major == '5' and int(minor) >= 17) or (major == '6' and int(minor) >= 3):
+    if (major == '5' and int(minor) >= 17):
       check_version = True
     return stack.name == 'CDH' and check_version
 

--- a/dp-cluster-setup-utility.py
+++ b/dp-cluster-setup-utility.py
@@ -635,12 +635,6 @@ class ClouderaManager(BaseClusterManager):
     except ApiException as e:
       raise NoClusterFound(e)
 
-  def get_cluster_instance(self, cluster_name):
-    for cluster in self.clusters:
-      if cluster.name == cluster_name:
-        return cluster
-    return None
-  
   def _find_internal_host_name(self):
     pass
 
@@ -1598,13 +1592,9 @@ class CMPrerequisites(BasePrerequisites):
     stack = cluster.installed_stack()
     check_version = False
     (major,minor) = stack.version.split('.')[:2]
-    if (major == '5' and int(minor) >= 17):
+    if (major == '5' and int(minor) >= 17) or (major == '6' and int(minor) >= 1):
       check_version = True
     return stack.name == 'CDH' and check_version
-
-  def security_type_supported(self):
-    pass
-
 
 class CookieThief:
   def __init__(self):
@@ -1794,7 +1784,7 @@ class CMRegistrationFlow(BaseRegistrationFlow):
           clusters_to_register = clusters_not_registered
         else:
           user_provided_clusters = []
-          cluster_input_file = user.input('Enter full path of file containing cluster names ', 'cm.cluster_file')
+          cluster_input_file = user.input('Enter full path of a file containing names of clusters you would like to register', 'cm.cluster_file')
           with open(cluster_input_file, 'r') as f:
             for line in f:
               user_provided_clusters.append(line.strip())


### PR DESCRIPTION
Tested scenarios
## one Cluster managed by CM

- register the cluster

```bash
Tell me about Cloudera Manager Instance
CM URL (http(s)://host:[port]) [http://abc:port]:
CM admin username [admin]:
CM admin password:
Checking communication between DataPlane and Cloudera Manager ...
Total clusters managed by Cloudera Manager Instance : 1
Registering cluster to DataPlane...
Enter details for cluster : Cluster 1
Data Center Name [DC1]: DC2
Cluster Descriptions [test]:
Cluster : Cluster 1 is registered with id : 44
Success! You are all set, your cluster is registered and ready to use.
```

## Two Cluster managed by CM 

-  Register ALL
```bash
Tell me about Cloudera Manager Instance
CM URL (http(s)://host:[port]) [http://abc:port]: 
CM admin username [admin]: 
CM admin password: 
Checking communication between DataPlane and Cloudera Manager ...
Total clusters managed by Cloudera Manager Instance : 2
Clusters already registered in DataPlane : 
Clusters which can be registered in DataPlane : Cluster 1,Cluster 2
Register all y/n [y]: y

Clusters which will be registered in DataPlane : Cluster 1,Cluster 2
Registering cluster to DataPlane...
Enter details for cluster : Cluster 1
Data Center Name [DC1]: 
Cluster Descriptions [test]: 
Enter details for cluster : Cluster 2
Data Center Name [DC1]: 
Cluster Descriptions [test]: 
Cluster : Cluster 1 is registered with id : 40 
Cluster : Cluster 2 is registered with id : 39 
Success! You are all set, your cluster is registered and ready to use.
```

- Register one cluster from file input

```bash
Tell me about Cloudera Manager Instance
CM URL (http(s)://host:[port]) [http://abc:port]: 
CM admin username [admin]: 
CM admin password: 
Checking communication between DataPlane and Cloudera Manager ...
Total clusters managed by Cloudera Manager Instance : 2
Clusters already registered in DataPlane : 
Clusters which can be registered in DataPlane : Cluster 1,Cluster 2
Register all y/n [y]: n
Enter full path of file containing cluster names  [cluster.txt]: 

Clusters which will be registered in DataPlane : Cluster 1
Registering cluster to DataPlane...
Enter details for cluster : Cluster 1
Data Center Name [DC1]: 
Cluster Descriptions [test]: 
Cluster : Cluster 1 is registered with id : 41
``` 

- Register remaining
```bash
Tell me about Cloudera Manager Instance
CM URL (http(s)://host:[port]) [http://abc:port]: 
CM admin username [admin]: 
CM admin password: 
Checking communication between DataPlane and Cloudera Manager ...
Total clusters managed by Cloudera Manager Instance : 2
Clusters already registered in DataPlane : Cluster 1
Clusters which can be registered in DataPlane : Cluster 2
Register all y/n [n]: y

Clusters which will be registered in DataPlane : Cluster 2
Registering cluster to DataPlane...
Enter details for cluster : Cluster 2
Data Center Name [DC1]: 
Cluster Descriptions [test]: 
Cluster : Cluster 2 is registered with id : 42 
Success! You are all set, your cluster is registered and ready to use.
```
